### PR TITLE
Custom exception layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Via Composer:
 $ composer require --dev osteel/openapi-httpfoundation-testing
 ```
 
-> 💡 This package is meant to be used for development only, as part of your API test suite.
+💡 _This package is meant to be used for development only, as part of your API test suite._
 
 ## Usage
 
@@ -41,7 +41,7 @@ First, import the builder in the class that will perform the validation:
 use Osteel\OpenApi\Testing\ResponseValidatorBuilder;
 ```
 
-Use the builder to create a `Osteel\OpenApi\Testing\ResponseValidator` object, feeding it a YAML or JSON OpenAPI definition:
+Use the builder to create a `\Osteel\OpenApi\Testing\ResponseValidator` object, feeding it a YAML or JSON OpenAPI definition:
 
 ```php
 $validator = ResponseValidatorBuilder::fromYaml('my-definition.yaml')->getValidator();
@@ -51,15 +51,15 @@ $validator = ResponseValidatorBuilder::fromYaml('my-definition.yaml')->getValida
 $validator = ResponseValidatorBuilder::fromJson('my-definition.json')->getValidator();
 ```
 
-> 💡 Instead of a file, you can also pass a YAML or JSON string directly.
+💡 _Instead of a file, you can also pass a YAML or JSON string directly._
 
-You can now validate a `Symfony\Component\HttpFoundation\Response` object for a given [path](https://swagger.io/specification/#paths-object) and method:
+You can now validate a `\Symfony\Component\HttpFoundation\Response` object for a given [path](https://swagger.io/specification/#paths-object) and method:
 
 ```php
 $validator->validate('/users', 'post', $response);
 ```
 
-> 💡 For convenience, responses implementing `Psr\Http\Message\ResponseInterface` are also accepted.
+💡 _For convenience, responses implementing `\Psr\Http\Message\ResponseInterface` are also accepted._
 
 In the example above, we check that the response matches the OpenAPI definition for a `POST` request on the `/users` path.
 
@@ -69,7 +69,7 @@ Each of OpenAPI's supported HTTP methods (`GET`, `POST`, `PUT`, `PATCH`, `DELETE
 $validator->post('/users', $response);
 ```
 
-The `validate` method returns `true` in case of success, and throws [PSR-7 message-related exceptions](https://github.com/thephpleague/openapi-psr7-validator#exceptions) from the underlying OpenAPI PSR-7 Message Validator package in case of error.
+The `validate` method returns `true` in case of success, and throws `\Osteel\OpenApi\Testing\Exceptions\ValidationException` exceptions in case of error.
 
 ## Change log
 

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Osteel\OpenApi\Testing\Exceptions;
+
+use Exception;
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
+
+class ValidationException extends Exception
+{
+    /**
+     * Build a new exception based on a ValidationFailed one.
+     *
+     * @param  ValidationFailed $exception
+     * @return ValidationException
+     */
+    public static function fromValidationFailed(ValidationFailed $exception): ValidationException
+    {
+        $previous = $exception;
+        $message  = $exception->getMessage();
+
+        while ($exception = $exception->getPrevious()) {
+            $message .= sprintf(': %s', $exception->getMessage());
+        }
+
+        return new ValidationException($message, 0, $previous);
+    }
+}

--- a/src/ResponseValidator.php
+++ b/src/ResponseValidator.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Osteel\OpenApi\Testing;
 
-use InvalidArgumentException;
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
 use League\OpenAPIValidation\PSR7\OperationAddress;
 use League\OpenAPIValidation\PSR7\ResponseValidator as BaseResponseValidator;
+use Osteel\OpenApi\Testing\Exceptions\ValidationException;
 
 /**
  * This class is a wrapper for League\OpenAPIValidation\PSR7\ResponseValidator objects,
@@ -44,8 +45,7 @@ final class ResponseValidator
      * @param  string $method   The HTTP method.
      * @param  object $response The response object to validate.
      * @return bool
-     * @throws InvalidArgumentException
-     * @throws \League\OpenAPIValidation\PSR7\Exception\ValidationFailed
+     * @throws ValidationException
      */
     public function validate(string $path, string $method, object $response): bool
     {
@@ -54,7 +54,11 @@ final class ResponseValidator
 
         $operation = new OperationAddress($path, strtolower($method));
 
-        $this->validator->validate($operation, $this->adapter->convert($response));
+        try {
+            $this->validator->validate($operation, $this->adapter->convert($response));
+        } catch (ValidationFailed $exception) {
+            throw ValidationException::fromValidationFailed($exception);
+        }
 
         return true;
     }

--- a/tests/Exceptions/ValidationExceptionTest.php
+++ b/tests/Exceptions/ValidationExceptionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Osteel\OpenApi\Testing\Tests\Exceptions;
+
+use Exception;
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
+use Osteel\OpenApi\Testing\Exceptions\ValidationException;
+use Osteel\OpenApi\Testing\Tests\TestCase;
+
+class ValidationExceptionTest extends TestCase
+{
+    public function testItCreatesAnExceptionFromAValidationFailedException()
+    {
+        $exception = new ValidationFailed('foo', 0, new Exception('bar', 0, new Exception('baz')));
+        $sut       = ValidationException::fromValidationFailed($exception);
+
+        $this->assertEquals('foo: bar: baz', $sut->getMessage());
+        $this->assertEquals($exception, $sut->getPrevious());
+    }
+}

--- a/tests/ResponseValidatorTest.php
+++ b/tests/ResponseValidatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Osteel\OpenApi\Testing\Tests;
 
+use Osteel\OpenApi\Testing\Exceptions\ValidationException;
 use Osteel\OpenApi\Testing\ResponseValidator;
 use Osteel\OpenApi\Testing\ResponseValidatorBuilder;
 
@@ -23,7 +24,7 @@ class ResponseValidatorTest extends TestCase
 
     public function testItDoesNotValidateTheHttpFoundationResponse()
     {
-        $this->expectException(\League\OpenAPIValidation\PSR7\Exception\ValidationFailed::class);
+        $this->expectException(ValidationException::class);
 
         $this->sut->validate('/test', 'get', $this->httpFoundationResponse(['baz' => 'bar']));
     }
@@ -37,7 +38,7 @@ class ResponseValidatorTest extends TestCase
 
     public function testItDoesNotValidateThePsr7MessageResponse()
     {
-        $this->expectException(\League\OpenAPIValidation\PSR7\Exception\ValidationFailed::class);
+        $this->expectException(ValidationException::class);
 
         $this->sut->validate('/test', 'get', $this->psr7Response(['baz' => 'bar']));
     }


### PR DESCRIPTION
## Description

This PR adds a wrapper for the underlying package's exceptions.

## Motivation and context

The [OpenAPI PSR-7 Validator](https://github.com/thephpleague/openapi-psr7-validator) package throws exceptions which are a chain of exceptions linked to each other via the `getPrevious()` method.

While there is nothing wrong with this design, when getting these exceptions during a test suite execution the actual validation error does not appear clearly.

The wrapper introduced with this PR goes up the exception chain and aggregates the error messages as a single one.

Another advantage is that the current package's users should now only expect `\Osteel\OpenApi\Testing\Exceptions\ValidationException` exceptions where unforeseen exception changes in the underlying package could previously occur.