### PR TITLE
Add support to validate HttpFoundation Requests and PSR ServerRequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.com/osteel/openapi-httpfoundation-testing.svg?token=SDx8eeySnDpzswpLVTU3&branch=main)](https://travis-ci.com/osteel/openapi-httpfoundation-testing)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/osteel/openapi-httpfoundation-testing/badges/quality-score.png?b=main&s=bef9ddbf29dac69612a3092e4761e14ce768bccd)](https://scrutinizer-ci.com/g/osteel/openapi-httpfoundation-testing/?branch=main)
 
-Strengthen your API tests by validating HttpFoundation responses against OpenAPI (3.0.x) definitions.
+Strengthen your API tests by validating HttpFoundation requests and responses against OpenAPI (3.0.x) definitions.
 
 See [this article](https://tech.osteel.me/posts/openapi-backed-api-testing-in-php-projects-a-laravel-example "OpenAPI-backed API testing in PHP projects – a Laravel example") for more details, and [this repository](https://github.com/osteel/openapi-httpfoundation-testing-laravel-example) for an example use in a Laravel project.
 
@@ -13,7 +13,7 @@ See [this article](https://tech.osteel.me/posts/openapi-backed-api-testing-in-ph
 
 [OpenAPI](https://swagger.io/specification/) is a specification intended to describe RESTful APIs in a way that is understood by humans and machines alike.
 
-By validating an API's responses against the OpenAPI definition that describes it, we guarantee that the API's behaviour conforms to the documentation we provide, thus making the OpenAPI definition the single source of truth.
+By validating an API's responses against the OpenAPI definition that describes it, we guarantee that the API's behaviour conforms to the documentation we provide, thus making the OpenAPI definition the single source of truth. The request validation on the other hand supports you in the process of doing the server side validation of the requests payloads. 
 
 The [HttpFoundation component](https://symfony.com/doc/current/components/http_foundation.html) is developed and maintained as part of the [Symfony framework](https://symfony.com/). It is used to handle HTTP requests and responses in projects such as Symfony, Laravel, Drupal, and many other major industry players (see the [extended list](https://symfony.com/components/HttpFoundation)).
 
@@ -21,7 +21,7 @@ The [HttpFoundation component](https://symfony.com/doc/current/components/http_f
 
 This package is built upon the [OpenAPI PSR-7 Message Validator](https://github.com/thephpleague/openapi-psr7-validator) package, which validates [PSR-7 messages](https://www.php-fig.org/psr/psr-7/) against OpenAPI definitions.
 
-It essentially converts HttpFoundation response objects to PSR-7 messages using Symfony's [PSR-7 Bridge](https://symfony.com/doc/current/components/psr7.html) and [Tobias Nyholm](https://github.com/Nyholm)'s [PSR-7 implementation](https://github.com/Nyholm/psr7), before passing them on to the OpenAPI PSR-7 Message Validator.
+It essentially converts HttpFoundation response and request objects to PSR-7 messages using Symfony's [PSR-7 Bridge](https://symfony.com/doc/current/components/psr7.html) and [Tobias Nyholm](https://github.com/Nyholm)'s [PSR-7 implementation](https://github.com/Nyholm/psr7), before passing them on to the OpenAPI PSR-7 Message Validators.
 
 ## Install
 
@@ -35,6 +35,7 @@ $ composer require --dev osteel/openapi-httpfoundation-testing
 
 ## Usage
 
+### Response Validation
 First, import the builder in the class that will perform the validation:
 
 ```php
@@ -68,6 +69,35 @@ Each of OpenAPI's supported HTTP methods (`GET`, `POST`, `PUT`, `PATCH`, `DELETE
 ```php
 $validator->post('/users', $response);
 ```
+
+The `validate` method returns `true` in case of success, and throws `\Osteel\OpenApi\Testing\Exceptions\ValidationException` exceptions in case of error.
+
+### Request Validation
+The procedure is the same as described in the [Response Validation](https://github.com/osteel/openapi-httpfoundation-testing#response-validation) section. Import the builder first: 
+
+```php
+use Osteel\OpenApi\Testing\RequestValidatorBuilder;
+```
+
+and use it to create a `\Osteel\OpenApi\Testing\RequestValidator` object, feeding it a YAML or JSON OpenAPI definition:
+
+```php
+$validator = RequestValidatorBuilder::fromYaml('my-definition.yaml')->getValidator();
+
+// or
+
+$validator = RequestValidatorBuilder::fromJson('my-definition.json')->getValidator();
+```
+
+💡 _Instead of a file, you can also pass a YAML or JSON string directly._
+
+You can now validate a `\Symfony\Component\HttpFoundation\Request` object:
+
+```php
+$validator->validate($request);
+```
+
+💡 _For convenience, requests implementing `\Psr\Http\Message\ServerRequestInterface` are also accepted._
 
 The `validate` method returns `true` in case of success, and throws `\Osteel\OpenApi\Testing\Exceptions\ValidationException` exceptions in case of error.
 

--- a/src/HttpFoundation/HttpFoundationRequestAdapter.php
+++ b/src/HttpFoundation/HttpFoundationRequestAdapter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Osteel\OpenApi\Testing\HttpFoundation;
+
+use InvalidArgumentException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Osteel\OpenApi\Testing\RequestAdapter;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Component\HttpFoundation\Request;
+
+class HttpFoundationRequestAdapter implements RequestAdapter
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param  Request|ServerRequestInterface $request The request object to convert.
+     * @return ServerRequestInterface
+     * @throws InvalidArgumentException
+     */
+    public function convert(object $request): ServerRequestInterface
+    {
+        if ($request instanceof ServerRequestInterface) {
+            return $request;
+        }
+
+        if ($request instanceof Request) {
+            $psr17Factory   = new Psr17Factory();
+            $psrHttpFactory = new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
+
+            return $psrHttpFactory->createRequest($request);
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Can only validate requests of type %s or %s; %s received',
+            Request::class,
+            ServerRequestInterface::class,
+            get_class($request)
+        ));
+    }
+}

--- a/src/RequestAdapter.php
+++ b/src/RequestAdapter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Osteel\OpenApi\Testing;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+interface RequestAdapter
+{
+    /**
+     * Convert a request to a PSR-7 HTTP message.
+     *
+     * @param  object $request The request object to convert.
+     * @return ServerRequestInterface
+     */
+    public function convert(object $request): ServerRequestInterface;
+}

--- a/src/RequestValidator.php
+++ b/src/RequestValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Osteel\OpenApi\Testing;
+
+use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
+use League\OpenAPIValidation\PSR7\RequestValidator as BaseRequestValidator;
+use Osteel\OpenApi\Testing\Exceptions\ValidationException;
+
+/**
+ * This class is a wrapper for League\OpenAPIValidation\PSR7\RequestValidator objects,
+ * providing an interface to validate HTTP requests against an OpenAPI definition.
+ */
+final class RequestValidator
+{
+    /**
+     * @var \League\OpenAPIValidation\PSR7\RequestValidator
+     */
+    private $validator;
+
+    /**
+     * @var RequestAdapter
+     */
+    private $adapter;
+
+    /**
+     * Constructor.
+     *
+     * @param  \League\OpenAPIValidation\PSR7\RequestValidator $validator
+     * @param  RequestAdapter                                  $adapter
+     * @return void
+     */
+    public function __construct(BaseRequestValidator $validator, RequestAdapter $adapter)
+    {
+        $this->validator = $validator;
+        $this->adapter   = $adapter;
+    }
+
+    /**
+     * Validate a request against the specified OpenAPI definition.
+     *
+     * @param  object $request The request object to validate.
+     *
+     * @return bool
+     * @throws ValidationException
+     */
+    public function validate(object $request): bool
+    {
+        try {
+            $this->validator->validate($this->adapter->convert($request));
+        } catch (ValidationFailed $exception) {
+            throw ValidationException::fromValidationFailed($exception);
+        }
+
+        return true;
+    }
+}

--- a/src/RequestValidatorBuilder.php
+++ b/src/RequestValidatorBuilder.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Osteel\OpenApi\Testing;
+
+use InvalidArgumentException;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use Osteel\OpenApi\Testing\HttpFoundation\HttpFoundationRequestAdapter;
+
+/**
+ * This class creates RequestValidator objects based on OpenAPI definitions.
+ */
+class RequestValidatorBuilder
+{
+    /**
+     * @var ValidatorBuilder
+     */
+    protected $validatorBuilder;
+
+    /**
+     * @var string
+     */
+    protected $adapter = HttpFoundationRequestAdapter::class;
+
+    /**
+     * Constructor.
+     *
+     * @param  ValidatorBuilder $builder
+     * @return void
+     */
+    public function __construct(ValidatorBuilder $builder)
+    {
+        $this->validatorBuilder = $builder;
+    }
+
+    /**
+     * Create a RequestValidator object based on a YAML OpenAPI definition.
+     *
+     * @param  string $definition The OpenAPI definition.
+     * @return RequestValidatorBuilder
+     */
+    public static function fromYaml(string $definition): RequestValidatorBuilder
+    {
+        $method = is_file($definition) ? 'fromYamlFile' : 'fromYaml';
+
+        return self::fromMethod($method, $definition);
+    }
+
+    /**
+     * Create a RequestValidator object based on a JSON OpenAPI definition.
+     *
+     * @param  string $definition The OpenAPI definition.
+     * @return RequestValidatorBuilder
+     */
+    public static function fromJson(string $definition): RequestValidatorBuilder
+    {
+        $method = is_file($definition) ? 'fromJsonFile' : 'fromJson';
+
+        return self::fromMethod($method, $definition);
+    }
+
+    /**
+     * Create a RequestValidator object based on an OpenAPI definition.
+     *
+     * @param  string $method     The ValidatorBuilder object's method to use.
+     * @param  string $definition The OpenAPI definition.
+     * @return RequestValidatorBuilder
+     */
+    private static function fromMethod(string $method, string $definition): RequestValidatorBuilder
+    {
+        $builder = (new ValidatorBuilder())->$method($definition);
+
+        return new RequestValidatorBuilder($builder);
+    }
+
+    /**
+     * Return the RequestValidator object.
+     *
+     * @return RequestValidator
+     */
+    public function getValidator(): RequestValidator
+    {
+        return new RequestValidator($this->validatorBuilder->getRequestValidator(), new $this->adapter());
+    }
+
+    /**
+     * Change the request adapter to be used. The provided class must
+     * implement the \Osteel\OpenApi\Testing\RequestAdapter interface.
+     *
+     * @param  string $class The adapter's class.
+     * @return self
+     * @throws InvalidArgumentException
+     */
+    public function setAdapter(string $class): self
+    {
+        if (! is_subclass_of($class, RequestAdapter::class)) {
+            throw new InvalidArgumentException(sprintf(
+                'Class %s does not implement the %s interface',
+                $class,
+                RequestAdapter::class
+            ));
+        }
+
+        $this->adapter = $class;
+
+        return $this;
+    }
+}

--- a/tests/HttpFoundation/HttpFoundationRequestAdapterTest.php
+++ b/tests/HttpFoundation/HttpFoundationRequestAdapterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Osteel\OpenApi\Testing\Tests\HttpFoundation;
+
+use InvalidArgumentException;
+use Osteel\OpenApi\Testing\HttpFoundation\HttpFoundationRequestAdapter;
+use Osteel\OpenApi\Testing\Tests\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class HttpFoundationRequestAdapterTest extends TestCase
+{
+    /**
+     * @var HttpFoundationRequestAdapter
+     */
+    private $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = new HttpFoundationRequestAdapter();
+    }
+
+    public function testItDoesNotConvertTheRequestBecauseItsTypeIsNotSupported()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Can only validate requests of type %s or %s; InvalidArgumentException received',
+            Request::class,
+            ServerRequestInterface::class
+        ));
+
+        $this->sut->convert(new InvalidArgumentException());
+    }
+
+    public function testItConvertsTheHttpFoundationRequest()
+    {
+        $result = $this->sut->convert(Request::create('/foo'));
+
+        $this->assertInstanceOf(ServerRequestInterface::class, $result);
+    }
+
+    public function testItLeavesTheRequestInterfaceUntouched()
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $result  = $this->sut->convert($request);
+
+        $this->assertEquals($request, $result);
+    }
+}

--- a/tests/RequestValidatorBuilderTest.php
+++ b/tests/RequestValidatorBuilderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Osteel\OpenApi\Testing\Tests;
+
+use InvalidArgumentException;
+use Osteel\OpenApi\Testing\RequestAdapter;
+use Osteel\OpenApi\Testing\RequestValidator;
+use Osteel\OpenApi\Testing\RequestValidatorBuilder;
+
+class RequestValidatorBuilderTest extends TestCase
+{
+    public function definitionProvider(): array
+    {
+        return [
+            ['fromYaml', self::$yamlDefinition],
+            ['fromYaml', file_get_contents(self::$yamlDefinition)],
+            ['fromJson', self::$jsonDefinition],
+            ['fromJson', file_get_contents(self::$jsonDefinition)],
+        ];
+    }
+
+    /**
+     * @dataProvider definitionProvider
+     */
+    public function testItBuildsARequestValidator(string $method, string $definition)
+    {
+        $result = RequestValidatorBuilder::$method($definition)->getValidator();
+
+        $this->assertInstanceOf(RequestValidator::class, $result);
+
+        // Validate a request to make sure the definition was correctly parsed.
+        $this->assertTrue($result->validate($this->httpFoundationRequest('/test', 'get', ['foo' => 'bar'])));
+    }
+
+    public function testItDoesNotSetTheAdapterBecauseItsTypeIsInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Class %s does not implement the %s interface',
+            InvalidArgumentException::class,
+            RequestAdapter::class
+        ));
+
+        RequestValidatorBuilder::fromYaml(self::$yamlDefinition)
+            ->setAdapter(InvalidArgumentException::class);
+    }
+
+    public function testItSetsTheAdapter()
+    {
+        RequestValidatorBuilder::fromYaml(self::$yamlDefinition)
+            ->setAdapter(get_class($this->createMock(RequestAdapter::class)));
+
+        // No exception means the test was successful.
+        $this->assertTrue(true);
+    }
+}

--- a/tests/RequestValidatorTest.php
+++ b/tests/RequestValidatorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Osteel\OpenApi\Testing\Tests;
+
+use Osteel\OpenApi\Testing\Exceptions\ValidationException;
+use Osteel\OpenApi\Testing\RequestValidator;
+use Osteel\OpenApi\Testing\RequestValidatorBuilder;
+
+class RequestValidatorTest extends TestCase
+{
+    /**
+     * @var RequestValidator
+     */
+    private $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = RequestValidatorBuilder::fromYaml(self::$yamlDefinition)->getValidator();
+    }
+
+    public function bodylessMethodProvider(): array
+    {
+        return [
+            ['get'],
+            ['delete'],
+            ['head'],
+            ['options'],
+            ['trace'],
+        ];
+    }
+
+    /**
+     * @dataProvider bodylessMethodProvider
+     */
+    public function testItValidatesHttpFoundationRequestWithoutPayload(string $method)
+    {
+        $result = $this->sut->validate($this->httpFoundationRequest('/test', $method));
+
+        $this->assertTrue($result);
+    }
+
+    public function methodProvider(): array
+    {
+        return [
+            ['post'],
+            ['put'],
+            ['patch'],
+        ];
+    }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testItDoesNotValidateTheHttpFoundationRequest(string $method)
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->sut->validate($this->httpFoundationRequest('/test', $method, ['baz' => 'bar']));
+    }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testItValidatesTheHttpFoundationRequest(string $method)
+    {
+        $result = $this->sut->validate($this->httpFoundationRequest('/test', $method, ['foo' => 'bar']));
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider bodylessMethodProvider
+     */
+    public function testItDoesValidateThePsr7ServerRequestWithoutRequestBody(string $method)
+    {
+        $result = $this->sut->validate($this->psr7ServerRequest('/test', $method));
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testItDoesNotValidateThePsr7ServerRequest(string $method)
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->sut->validate($this->psr7ServerRequest('/test', $method, ['baz' => 'bar']));
+    }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testItValidatesThePsr7ServerRequest(string $method)
+    {
+        $result = $this->sut->validate($this->psr7ServerRequest('/test', $method, ['foo' => 'bar']));
+
+        $this->assertTrue($result);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Osteel\OpenApi\Testing\Tests;
 
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
+    private const BASE_URI = 'http://localhost:8000/api';
+
     /**
      * @var string
      */
@@ -54,5 +59,49 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $response->method('getHeader')->willReturn(['application/json']);
 
         return $response;
+    }
+
+    /**
+     * Return a HttpFoundation request with the provided content.
+     *
+     * @param  string $uri
+     * @param  string $method
+     * @param  array $content
+     * @return Request
+     */
+    protected function httpFoundationRequest(string $uri, string $method, array $content = null): Request
+    {
+        return Request::create(
+            self::BASE_URI . $uri,
+            $method,
+            [],
+            [],
+            [],
+            $content ? ['CONTENT_TYPE' => 'application/json'] : [],
+            $content ? json_encode($content) : ''
+        );
+    }
+
+    /**
+     * Return a PSR-7 server request with the provided content.
+     *
+     * @param  array $content
+     * @return ServerRequestInterface
+     */
+    protected function psr7ServerRequest(
+        string $uri,
+        string $method,
+        array $content = null
+    ): ServerRequestInterface {
+        $psr17Factory = new Psr17Factory();
+        $uri          = $psr17Factory->createUri(self::BASE_URI . $uri);
+        $stream       = $psr17Factory->createStream(json_encode($content));
+        $request      = $psr17Factory->createServerRequest($method, $uri);
+        if ($content) {
+            $request = $request->withHeader('Content-Type', 'application/json');
+        }
+
+
+        return $request->withBody($stream);
     }
 }

--- a/tests/stubs/example.json
+++ b/tests/stubs/example.json
@@ -35,6 +35,23 @@
         }
       },
       "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "foo"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "204": {
             "description": "No content"
@@ -42,6 +59,23 @@
         }
       },
       "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "foo"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "204": {
             "description": "No content"
@@ -49,6 +83,23 @@
         }
       },
       "patch": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "foo": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "foo"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "204": {
             "description": "No content"

--- a/tests/stubs/example.yaml
+++ b/tests/stubs/example.yaml
@@ -24,14 +24,44 @@ paths:
                     type: string
                     example: bar
     post:
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: string
+              required:
+                - foo
       responses:
         '204':
           description: No content
     put:
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: string
+              required:
+                - foo
       responses:
         '204':
           description: No content
     patch:
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: string
+              required:
+                - foo
       responses:
         '204':
           description: No content


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added support for validating requests following the same pattern as provided by the package when validating the responses

## Motivation and context

Request validation is provided by the underlying [league/openapi-psr7-validator](https://github.com/thephpleague/openapi-psr7-validator) package 

## How has this been tested?

Following the same approach as the reponse testing. The (invalid) OpenAPI example has been extended and a required request body definition added to the `POST`, `PUT` and `PATCH` operations.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.


