### PR TITLE
Laravel 6.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "authors": [
         {
             "name": "Yannick Chenot",
-            "email": "hello@yannickchenot.com",
+            "email": "yannick@yellowraincoat.co.uk",
             "homepage": "https://github.com/osteel",
             "role": "Maintainer"
         }
@@ -28,7 +28,7 @@
         "league/openapi-psr7-validator": "^0.16.1",
         "nyholm/psr7": "^1.4",
         "psr/http-message": "^1.0",
-        "symfony/http-foundation": "^5.3",
+        "symfony/http-foundation": "^4.4 || ^5.3",
         "symfony/psr-http-message-bridge": "^2.1"
     },
     "require-dev": {


### PR DESCRIPTION
## Description

Fixes #10 

## Motivation and context

Laravel 6.x requires `symfony/http-foundation` v4.x. This PR adds this version to `composer.json`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
