### PR TITLE
Broaden dependency version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     strategy:
       matrix:
         php-version:
+          - "7.2"
+          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/.DS_Store
+build
 composer.lock
 vendor
 phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     "require": {
         "php": "^7.2|^8.0",
         "ext-json": "*",
-        "league/openapi-psr7-validator": "^0.16.1",
-        "nyholm/psr7": "^1.4",
+        "league/openapi-psr7-validator": "^0.16",
+        "nyholm/psr7": "^1.0",
         "psr/http-message": "^1.0",
-        "symfony/http-foundation": "^4.4 || ^5.3",
-        "symfony/psr-http-message-bridge": "^2.1"
+        "symfony/http-foundation": "^4.0 || ^5.0 || ^6.0",
+        "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=8.0",


### PR DESCRIPTION
## Description

This PR broadens dependency version support, including Symfony 6.

## Motivation and context

Symfony 6 was released a few months ago and with it also came a new version of the HTTP Foundation component.

Also made other dependency versions less restrictive. 

## How has this been tested?

GitHub CI.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
