### PR TITLE
Dependency Update - league/openapi-psr7-validator to 0.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "ext-json": "*",
-        "league/openapi-psr7-validator": "^0.16",
+        "league/openapi-psr7-validator": "^0.17",
         "nyholm/psr7": "^1.0",
         "psr/http-message": "^1.0",
         "symfony/http-foundation": "^4.0 || ^5.0 || ^6.0",


### PR DESCRIPTION
This dependency update is to introduce the fix for https://github.com/thephpleague/openapi-psr7-validator/issues/154

## Description

Bumped version from 0.16 to 0.17

## Motivation and context

This is required due to an update to cebe/open-api for nullable.

## How has this been tested?

`composer test`

```
..................................                         41 / 41 (100%)

Time: 00:00.185, Memory: 12.00 MB

OK (41 tests, 52 assertions)
```

```
➜  openapi-httpfoundation-testing git:(feature/league-psr7-dependency-update) composer --version
Composer version 2.2.6 2022-02-04 17:00:38
➜  openapi-httpfoundation-testing git:(feature/league-psr7-dependency-update) php -v
PHP 8.1.2 (cli) (built: Jan 21 2022 04:46:45) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.2, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.2, Copyright (c), by Zend Technologies
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
