### PR TITLE
OpenAPI 3.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.2"
           - "7.3"
           - "7.4"
           - "8.0"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://poser.pugx.org/osteel/openapi-httpfoundation-testing/license)](//packagist.org/packages/osteel/openapi-httpfoundation-testing)
 [![Downloads](http://poser.pugx.org/osteel/openapi-httpfoundation-testing/downloads)](//packagist.org/packages/osteel/openapi-httpfoundation-testing)
 
-Validate HttpFoundation requests and responses against OpenAPI (3.0.x) definitions.
+Validate HttpFoundation requests and responses against OpenAPI (3+) definitions.
 
 See [this post](https://tech.osteel.me/posts/openapi-backed-api-testing-in-php-projects-a-laravel-example "OpenAPI-backed API testing in PHP projects – a Laravel example") for more details and [this repository](https://github.com/osteel/openapi-httpfoundation-testing-laravel-example) for an example use in a Laravel project.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "osteel/openapi-httpfoundation-testing",
     "type": "library",
-    "description": "Validate HttpFoundation requests and responses against OpenAPI (3.0.x) definitions",
+    "description": "Validate HttpFoundation requests and responses against OpenAPI (3+) definitions",
     "keywords": [
         "openapi",
         "httpfoundation",
@@ -23,16 +23,16 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
-        "league/openapi-psr7-validator": "^0.17",
+        "league/openapi-psr7-validator": "^0.19",
         "nyholm/psr7": "^1.0",
         "psr/http-message": "^1.0",
         "symfony/http-foundation": "^4.0 || ^5.0 || ^6.0",
         "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=8.5.23",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {


### PR DESCRIPTION
## Description

This PR bumps the version of [OpenAPI PSR7 Validator](https://github.com/thephpleague/openapi-psr7-validator) for OpenAPI 3.1 support.

It also upgrades PHPUnit to v9.0+ and drops support for PHP 7.2.

## Motivation and context

OpenAPI 3.1 was released 2 years ago, but support for it was blocked by an [underlying package](https://github.com/cebe/php-openapi) that seems pretty much abandoned.

The community stepped up and forked it to finally provide support for OpenAPI 3.1, which was introduced with [this PR](https://github.com/thephpleague/openapi-psr7-validator/pull/185). 

## How has this been tested?

Test suite.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
