### PR TITLE
Revert use of union types

### DIFF
--- a/src/Adapters/AdapterInterface.php
+++ b/src/Adapters/AdapterInterface.php
@@ -5,17 +5,13 @@ declare(strict_types=1);
 namespace Osteel\OpenApi\Testing\Adapters;
 
 use Psr\Http\Message\MessageInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 interface AdapterInterface
 {
     /**
      * Convert a HTTP message to a PSR-7 HTTP message.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to convert
+     * @param object $message the HTTP message to convert
      */
-    public function convert(Request|Response|ResponseInterface|ServerRequestInterface $message): MessageInterface;
+    public function convert(object $message): MessageInterface;
 }

--- a/src/Adapters/HttpFoundationAdapter.php
+++ b/src/Adapters/HttpFoundationAdapter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Osteel\OpenApi\Testing\Adapters;
 
+use InvalidArgumentException;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -17,9 +18,9 @@ final class HttpFoundationAdapter implements AdapterInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to convert
+     * @param object $message the HTTP message to convert
      */
-    public function convert(Request|Response|ResponseInterface|ServerRequestInterface $message): MessageInterface
+    public function convert(object $message): MessageInterface
     {
         if ($message instanceof ResponseInterface || $message instanceof ServerRequestInterface) {
             return $message;
@@ -32,6 +33,10 @@ final class HttpFoundationAdapter implements AdapterInterface
             return $psrHttpFactory->createResponse($message);
         }
 
-        return $psrHttpFactory->createRequest($message);
+        if ($message instanceof Request) {
+            return $psrHttpFactory->createRequest($message);
+        }
+
+        throw new InvalidArgumentException(sprintf('Unsupported %s object received', $message::class));
     }
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -11,9 +11,6 @@ use League\OpenAPIValidation\PSR7\RoutedServerRequestValidator;
 use Osteel\OpenApi\Testing\Adapters\AdapterInterface;
 use Osteel\OpenApi\Testing\Exceptions\ValidationException;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 final class Validator implements ValidatorInterface
 {
@@ -27,17 +24,14 @@ final class Validator implements ValidatorInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
-     * @param string                                                    $method  the HTTP method
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
+     * @param string $method  the HTTP method
      *
      * @throws ValidationException
      */
-    public function validate(
-        Request|Response|ResponseInterface|ServerRequestInterface $message,
-        string $path,
-        string $method,
-    ): bool {
+    public function validate(object $message, string $path, string $method): bool
+    {
         $message = $this->adapter->convert($message);
         $operation = $this->getOperationAddress($path, $method);
         $validator = $message instanceof ResponseInterface ? $this->responseValidator : $this->requestValidator;
@@ -68,12 +62,12 @@ final class Validator implements ValidatorInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function delete(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool
+    public function delete(object $message, string $path): bool
     {
         return $this->validate($message, $path, 'delete');
     }
@@ -81,12 +75,12 @@ final class Validator implements ValidatorInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function get(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool
+    public function get(object $message, string $path): bool
     {
         return $this->validate($message, $path, 'get');
     }
@@ -94,12 +88,12 @@ final class Validator implements ValidatorInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function head(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool
+    public function head(object $message, string $path): bool
     {
         return $this->validate($message, $path, 'head');
     }
@@ -107,12 +101,12 @@ final class Validator implements ValidatorInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function options(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool
+    public function options(object $message, string $path): bool
     {
         return $this->validate($message, $path, 'options');
     }
@@ -120,12 +114,12 @@ final class Validator implements ValidatorInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function patch(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool
+    public function patch(object $message, string $path): bool
     {
         return $this->validate($message, $path, 'patch');
     }
@@ -133,12 +127,12 @@ final class Validator implements ValidatorInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function post(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool
+    public function post(object $message, string $path): bool
     {
         return $this->validate($message, $path, 'post');
     }
@@ -146,12 +140,12 @@ final class Validator implements ValidatorInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function put(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool
+    public function put(object $message, string $path): bool
     {
         return $this->validate($message, $path, 'put');
     }
@@ -159,12 +153,12 @@ final class Validator implements ValidatorInterface
     /**
      * @inheritDoc
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function trace(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool
+    public function trace(object $message, string $path): bool
     {
         return $this->validate($message, $path, 'trace');
     }

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -6,101 +6,97 @@ namespace Osteel\OpenApi\Testing;
 
 use League\OpenAPIValidation\PSR7\Exception\ValidationFailed;
 use Osteel\OpenApi\Testing\Exceptions\ValidationException;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 interface ValidatorInterface
 {
     /**
      * Validate a HTTP message against the specified OpenAPI definition.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
-     * @param string                                                    $method  the HTTP method
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
+     * @param string $method  the HTTP method
      *
      * @throws ValidationException
      */
-    public function validate(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path, string $method): bool;
+    public function validate(object $message, string $path, string $method): bool;
 
     /**
      * Validate a HTTP message for a DELETE operation on the provided OpenAPI definition path.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function delete(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool;
+    public function delete(object $message, string $path): bool;
 
     /**
      * Validate a HTTP message for a GET operation on the provided OpenAPI definition path.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function get(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool;
+    public function get(object $message, string $path): bool;
 
     /**
      * Validate a HTTP message for a HEAD operation on the provided OpenAPI definition path.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function head(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool;
+    public function head(object $message, string $path): bool;
 
     /**
      * Validate a HTTP message for a OPTIONS operation on the provided OpenAPI definition path.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function options(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool;
+    public function options(object $message, string $path): bool;
 
     /**
      * Validate a HTTP message for a PATCH operation on the provided OpenAPI definition path.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function patch(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool;
+    public function patch(object $message, string $path): bool;
 
     /**
      * Validate a HTTP message for a POST operation on the provided OpenAPI definition path.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function post(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool;
+    public function post(object $message, string $path): bool;
 
     /**
      * Validate a HTTP message for a PUT operation on the provided OpenAPI definition path.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function put(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool;
+    public function put(object $message, string $path): bool;
 
     /**
      * Validate a HTTP message for a TRACE operation on the provided OpenAPI definition path.
      *
-     * @param Request|Response|ResponseInterface|ServerRequestInterface $message the HTTP message to validate
-     * @param string                                                    $path    the OpenAPI path
+     * @param object $message the HTTP message to validate
+     * @param string $path    the OpenAPI path
      *
      * @throws ValidationFailed
      */
-    public function trace(Request|Response|ResponseInterface|ServerRequestInterface $message, string $path): bool;
+    public function trace(object $message, string $path): bool;
 }

--- a/tests/Adapters/HttpFoundationAdapterTest.php
+++ b/tests/Adapters/HttpFoundationAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Osteel\OpenApi\Testing\Tests\Adapters;
 
+use InvalidArgumentException;
 use Osteel\OpenApi\Testing\Adapters\HttpFoundationAdapter;
 use Osteel\OpenApi\Testing\Tests\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -18,6 +19,14 @@ class HttpFoundationAdapterTest extends TestCase
         parent::setUp();
 
         $this->sut = new HttpFoundationAdapter();
+    }
+
+    public function test_it_does_not_convert_the_message_because_the_type_is_not_supported()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported InvalidArgumentException object received');
+
+        $this->sut->convert(new InvalidArgumentException());
     }
 
     public function test_it_converts_the_http_foundation_request()


### PR DESCRIPTION
## Summary

This PR reverts the use of union types to narrow down the supported HTTP message types.

## Explanation

We do want the interface to be as open as possible – it's the adapters' job to then narrow the types down based on what they support.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
