### PR TITLE
PHPStan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,5 +9,6 @@
 /.php-cs-fixer.dist.php  export-ignore
 /.phpunit.result.cache   export-ignore
 /composer.lock           export-ignore
+/phpstan.neon.dist       export-ignore
 /phpunit.xml.dist        export-ignore
-rector.php               export-ignore
+/rector.php              export-ignore

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,24 +6,20 @@ We accept contributions via Pull Requests on Github.
 
 ## Pull Requests
 
-- **[PSR-12 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md)** - Fix the code style with `composer fix`.
+- **[PSR-12 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md)** - Fix the code's style with `composer fix`.
 
-- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+- **[PHPStan level 9](https://phpstan.org/user-guide/rule-levels)** - Check compliance with `composer type`.
+
+- **Add tests!** - Your contribution won't be accepted if it doesn't have tests – Run the test suite with `composer test`.
 
 - **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
 
 - **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
 
-- **Create feature branches** - Don't ask us to pull from your master branch.
+- **Create feature branches** - Don't ask us to pull from your main branch.
 
 - **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
 
 - **Send coherent history** - Make sure each individual commit in your pull request is meaningful.
-
-## Testing
-
-```bash
-$ composer test
-```
 
 **Happy coding**!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup PHP
+      - name: Set up PHP
         uses: shivammathur/setup-php@v2
 
       - name: Install composer dependencies
@@ -24,6 +24,23 @@ jobs:
 
       - name: Check coding style
         run: vendor/bin/php-cs-fixer fix --dry-run
+
+  type:
+    name: Type
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Check code typing
+        run: vendor/bin/phpstan
 
   tests:
     name: Tests
@@ -55,5 +72,5 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependency-versions }}
 
-      - name: Run PHPUnit
+      - name: Run tests
         run: vendor/bin/phpunit tests

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.17",
+        "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.6",
         "rector/rector": "^0.17.1"
     },
@@ -52,8 +53,10 @@
     "scripts": {
         "fix": "php-cs-fixer fix -v",
         "test": "phpunit",
+        "type": "phpstan",
         "all": [
             "@fix",
+            "@type",
             "@test"
         ],
         "refactor": "rector process"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+	level: 9
+
+	paths:
+		- src
+
+	checkMissingCallableSignature: true

--- a/src/Adapters/HttpFoundationAdapter.php
+++ b/src/Adapters/HttpFoundationAdapter.php
@@ -6,7 +6,6 @@ namespace Osteel\OpenApi\Testing\Adapters;
 
 use InvalidArgumentException;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
@@ -20,7 +19,7 @@ final class HttpFoundationAdapter implements MessageAdapterInterface
      *
      * @param object $message the HTTP message to convert
      */
-    public function convert(object $message): MessageInterface
+    public function convert(object $message): ResponseInterface|ServerRequestInterface
     {
         if ($message instanceof ResponseInterface || $message instanceof ServerRequestInterface) {
             return $message;

--- a/src/Adapters/MessageAdapterInterface.php
+++ b/src/Adapters/MessageAdapterInterface.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Osteel\OpenApi\Testing\Adapters;
 
-use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 interface MessageAdapterInterface
 {
@@ -13,5 +14,5 @@ interface MessageAdapterInterface
      *
      * @param object $message the HTTP message to convert
      */
-    public function convert(object $message): MessageInterface;
+    public function convert(object $message): ResponseInterface|ServerRequestInterface;
 }

--- a/src/ValidatorBuilder.php
+++ b/src/ValidatorBuilder.php
@@ -16,8 +16,10 @@ use Osteel\OpenApi\Testing\Cache\Psr16Adapter;
  */
 final class ValidatorBuilder implements ValidatorBuilderInterface
 {
+    /** @var class-string<MessageAdapterInterface> */
     private string $adapter = HttpFoundationAdapter::class;
 
+    /** @var class-string<CacheAdapterInterface> */
     private string $cacheAdapter = Psr16Adapter::class;
 
     public function __construct(private BaseValidatorBuilder $validatorBuilder)


### PR DESCRIPTION
## Summary

This PR adds PHPStan to analyse the codebase's typing (level 9).

## Explanation

Potential breaking change – `MessageAdapterInterface@convert` now returns `ResponseInterface|ServerRequestInterface` instead of `MessageInterface`.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
