### PR TITLE
Support for older dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
         "php": "^8.0",
         "ext-json": "*",
         "league/openapi-psr7-validator": "^0.21",
-        "nyholm/psr7": "^1.0",
-        "psr/cache": "^3.0",
+        "nyholm/psr7": "^1.3.1",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-message": "^1.0",
-        "psr/simple-cache": "^3.0",
-        "symfony/cache": "^6.0",
-        "symfony/http-foundation": "^4.0 || ^5.0 || ^6.0",
-        "symfony/psr-http-message-bridge": "^2.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
+        "symfony/cache": "^5.0.9 || ^6.0",
+        "symfony/http-foundation": "^5.0.9 || ^6.0",
+        "symfony/psr-http-message-bridge": "^2.0.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.17",


### PR DESCRIPTION
## Summary

This PR restores support for some older dependency versions.

## Explanation

Having `symfony/cache` v6.0 as a constraint created some conflicts with frameworks and packages not supporting it (e.g. Symfony 5).

This PR adjusts all dependences to their minimum version supporting PHP 8+.

Fixes #35.

## Checklist

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
