### PR TITLE
Fix deprecation issues for PHP CS Fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -32,7 +32,7 @@ return $config->setRules([
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'fully_qualified_strict_types' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'general_phpdoc_tag_rename' => [
             'replacements' => ['inheritDocs' => 'inheritDoc'],
         ],
@@ -59,7 +59,7 @@ return $config->setRules([
             'strategy' => 'no_multi_line',
         ],
         'native_function_casing' => true,
-        'native_function_type_declaration_casing' => true,
+        'native_type_declaration_casing' => true,
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_blank_lines_after_phpdoc' => true,
@@ -96,7 +96,7 @@ return $config->setRules([
                 'yield_from',
             ],
         ],
-        'no_unneeded_curly_braces' => [
+        'no_unneeded_braces' => [
             'namespaces' => false,
         ],
         'no_unneeded_import_alias' => true,


### PR DESCRIPTION
## Summary <!-- a couple of lines summarising the work -->

As per #37 we caught some deprecations in PHP CS Fixer, this PR aims to solve them.

## Explanation <!-- deeper explanation to guide reviewers -->

Ran the following commands:

1. docker run --rm -v "$(pwd):/app" -w /app composer:2 install
1. docker run --rm -v "$(pwd):/app" -w /app composer:2 fix
1. docker run --rm -v "$(pwd):/app" -w /app composer:2 type
1. docker run --rm -v "$(pwd):/app" -w /app composer:2 test

All were fine.

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself ~and left comments to provide context~
- [x] I have covered the changes with tests as appropriate - N/A
- [x] I have made sure static analysis and other checks are successful
