### PR TITLE
Add PHP 8.3 to testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         dependency-versions:
           - "lowest"
           - "highest"


### PR DESCRIPTION
## Summary <!-- a couple of lines summarising the work -->

Since 8.3 is released I figured I'd add it to the testing matrix.

## Explanation <!-- deeper explanation to guide reviewers -->

Ran the following commands:

1. docker run --rm -v "$(pwd):/app" -w /app php:8.3-fpm-alpine ./vendor/bin/php-cs-fixer fix -v
1. docker run --rm -v "$(pwd):/app" -w /app php:8.3-fpm-alpine ./vendor/bin/phpunit
1. docker run --rm -v "$(pwd):/app" -w /app php:8.3-fpm-alpine ./vendor/bin/phpstan

All against 8.3 runtime, no errors (aside from PHP CS Fixer deprecations since #38 isn't merged yet).

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself ~and left comments to provide context~
- [x] I have covered the changes with tests as appropriate - N/A
- [x] I have made sure static analysis and other checks are successful
