### PR TITLE
Dependency bumps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "league/openapi-psr7-validator": "^0.21",
+        "league/openapi-psr7-validator": "^0.22",
         "nyholm/psr7": "^1.3.1",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/http-message": "^1.0 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "league/openapi-psr7-validator": "^0.21",
         "nyholm/psr7": "^1.3.1",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/cache": "^5.0.9 || ^6.0 || ^7.0",
         "symfony/http-foundation": "^5.0.9 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/cache": "^5.0.9 || ^6.0 || ^7.0",
         "symfony/http-foundation": "^5.0.9 || ^6.0 || ^7.0",
-        "symfony/psr-http-message-bridge": "^2.0.1 || ^7.0"
+        "symfony/psr-http-message-bridge": "^2.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.17",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ namespace Osteel\OpenApi\Testing\Tests;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -42,7 +43,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             return $response;
         }
 
-        $response->method('getBody')->willReturn(json_encode($content, JSON_THROW_ON_ERROR));
+        $body = $this->createMock(StreamInterface::class);
+        $body->method('__toString')->willReturn(json_encode($content, JSON_THROW_ON_ERROR));
+
+        $response->method('getBody')->willReturn($body);
         $response->method('getStatusCode')->willReturn(Response::HTTP_OK);
         $response->method('getHeader')->willReturn(['application/json']);
 


### PR DESCRIPTION
## Summary <!-- a couple of lines summarising the work -->

This PR broadens support for some dependency versions and upgrades `league/openapi-psr7-validator` to [v0.22](https://github.com/thephpleague/openapi-psr7-validator/releases/tag/0.22).

## Explanation <!-- deeper explanation to guide reviewers -->

This will provide better dependency version support overall.

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
