### PR TITLE
Add support for URLs to OpenAPI definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: Check coding style
-        run: vendor/bin/php-cs-fixer fix --dry-run
+        run: vendor/bin/php-cs-fixer fix --dry-run -v
 
   type:
     name: Type

--- a/tests/ValidatorBuilderTest.php
+++ b/tests/ValidatorBuilderTest.php
@@ -17,12 +17,16 @@ class ValidatorBuilderTest extends TestCase
     {
         return [
             ['fromYaml', self::$yamlDefinition],
+            ['fromYaml', 'https://raw.githubusercontent.com/osteel/openapi-httpfoundation-testing/refs/heads/main/tests/stubs/example.yaml'],
             ['fromYaml', file_get_contents(self::$yamlDefinition)],
             ['fromYamlFile', self::$yamlDefinition],
+            ['fromYamlFile', 'https://raw.githubusercontent.com/osteel/openapi-httpfoundation-testing/refs/heads/main/tests/stubs/example.yaml'],
             ['fromYamlString', file_get_contents(self::$yamlDefinition)],
             ['fromJson', self::$jsonDefinition],
+            ['fromJson', 'https://raw.githubusercontent.com/osteel/openapi-httpfoundation-testing/refs/heads/main/tests/stubs/example.json'],
             ['fromJson', file_get_contents(self::$jsonDefinition)],
             ['fromJsonFile', self::$jsonDefinition],
+            ['fromJsonFile', 'https://raw.githubusercontent.com/osteel/openapi-httpfoundation-testing/refs/heads/main/tests/stubs/example.json'],
             ['fromJsonString', file_get_contents(self::$jsonDefinition)],
         ];
     }


### PR DESCRIPTION
## Summary <!-- a couple of lines summarising the work -->

This PR adds support for URLs pointing to OpenAPI definitions.

## Explanation <!-- deeper explanation to guide reviewers -->

Fixes #46.

Instead of using [OpenAPI PSR-7 Message Validator](https://github.com/thephpleague/openapi-psr7-validator)'s methods to create `SpecObjectInterfaces` [objects](https://github.com/cebe/php-openapi/blob/master/src/SpecObjectInterface.php), I create them through the `Reader` [class](https://github.com/cebe/php-openapi/blob/master/src/Reader.php) directly, which supports both local files and URLs.

## Checklist <!-- fill in the space between brackets with an x to tick the box -->

- [x] I have provided a summary and an explanation
- [x] I have reviewed the PR myself and left comments to provide context
- [x] I have covered the changes with tests as appropriate
- [x] I have made sure static analysis and other checks are successful
