### PR TITLE
Run CI against PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         dependency-versions:
           - "lowest"
           - "highest"


### PR DESCRIPTION
## Summary <!-- a couple of lines summarising the work -->

This PR adds PHP 8.5 to the list of PHP versions to run CI against.
